### PR TITLE
fix: Correctly use system locale directory, so translation works

### DIFF
--- a/debian/patches/0001-Remove-unconditional-Gettext.bindtextdomain-call.patch
+++ b/debian/patches/0001-Remove-unconditional-Gettext.bindtextdomain-call.patch
@@ -1,0 +1,26 @@
+From 2e072567b91049d15bdca2f3e4853c9722abd213 Mon Sep 17 00:00:00 2001
+From: Ian Douglas Scott <idscott@system76.com>
+Date: Wed, 2 Dec 2020 09:01:14 -0800
+Subject: [PATCH] Remove unconditional Gettext.bindtextdomain call
+
+This breaks the use of a system locale directory.
+---
+ ding.js | 2 --
+ 1 file changed, 2 deletions(-)
+
+diff --git a/ding.js b/ding.js
+index cb39f24..50d9a3e 100755
+--- a/ding.js
++++ b/ding.js
+@@ -75,8 +75,6 @@ imports.searchPath.unshift(codePath);
+ const Prefs = imports.preferences;
+ const Gettext = imports.gettext;
+ 
+-Gettext.bindtextdomain("ding", GLib.build_filenamev([codePath, "locale"]));
+-
+ const DesktopManager = imports.desktopManager;
+ 
+ if (!errorFound) {
+-- 
+2.27.0
+

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -1,0 +1,1 @@
+0001-Remove-unconditional-Gettext.bindtextdomain-call.patch

--- a/debian/rules
+++ b/debian/rules
@@ -1,7 +1,7 @@
 #!/usr/bin/make -f
 
 %:
-	dh $@ --localedir=share/gnome-shell/extensions/ding@rastersoft.com/locale
+	dh $@
 
 override_dh_fixperms:
 	dh_fixperms -XcreateThumbnail.js -Xding.js


### PR DESCRIPTION
This seems to be an upstream issues, requiring more changes, so I'll send a patch or at least an issue upstream. But this should address our problem for for now.

Fixes https://github.com/pop-os/desktop-icons-ng/issues/4.