### PR TITLE
Fix error on Gnome Shell 3.36

### DIFF
--- a/debian/patches/0002-fix-gnome-3.36.patch
+++ b/debian/patches/0002-fix-gnome-3.36.patch
@@ -1,0 +1,13 @@
+diff --git a/dbusUtils.js b/dbusUtils.js
+index 10eb22a..63d5ebe 100644
+--- a/dbusUtils.js
++++ b/dbusUtils.js
+@@ -280,7 +280,7 @@ function init() {
+       ...params,
+     };
+ 
+-    let { parentHandle } = params ?? { parentHandle: ''};
++    let { parentHandle } = params || { parentHandle: ''};
+     if (!parentHandle && parentWindow) {
+       try {
+         imports.gi.versions.GdkX11 = '3.0';

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -1,1 +1,2 @@
 0001-Remove-unconditional-Gettext.bindtextdomain-call.patch
+0002-fix-gnome-3.36.patch


### PR DESCRIPTION
It seems the `??` operator doesn't work on 3.36. Since JavaScript "objects" always evaluate to true, `||` should be equivalent here.

Fixes https://github.com/pop-os/desktop-icons-ng/issues/13.